### PR TITLE
Fix iOS start script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start-web": "expo start --web --tunnel",
     "start-web-dev": "DEBUG=expo* expo start --web --tunnel",
     "android": "expo start --android",
-    "ios": "expor srart --ios"
+    "ios": "expo start --ios"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",


### PR DESCRIPTION
## Summary
- correct expo command for iOS script

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f4cefc7e48328b60f20b7411c38d0